### PR TITLE
require setting logger output channel to use it

### DIFF
--- a/src/lib/client/useLogger.ts
+++ b/src/lib/client/useLogger.ts
@@ -16,7 +16,7 @@ export function useLogger(tag: string, vscode?: VsCodeApi): ILogger {
   );
 }
 
-function createConsoleLogger(tag: string): ILogger {
+export function createConsoleLogger(tag: string): ILogger {
   return {
     debug: (message: string, data?: Record<string, unknown>) =>
       console.debug(`[${tag}] ${message}`, data),

--- a/src/lib/client/useLogger.ts
+++ b/src/lib/client/useLogger.ts
@@ -1,6 +1,6 @@
-/* eslint-disable no-console */
 import { useMemo } from 'react';
 import type { ILogger } from '../types';
+import { createConsoleLogger } from '../utils';
 import { WebviewLogger } from './WebviewLogger';
 import type { VsCodeApi } from './types';
 
@@ -14,18 +14,4 @@ export function useLogger(tag: string, vscode?: VsCodeApi): ILogger {
     () => (vscode === undefined ? createConsoleLogger(tag) : new WebviewLogger(vscode, tag)),
     [vscode, tag]
   );
-}
-
-export function createConsoleLogger(tag: string): ILogger {
-  return {
-    debug: (message: string, data?: Record<string, unknown>) =>
-      console.debug(`[${tag}] ${message}`, data),
-    info: (message: string, data?: Record<string, unknown>) =>
-      console.info(`[${tag}] ${message}`, data),
-    warn: (message: string, data?: Record<string, unknown>) =>
-      console.warn(`[${tag}] ${message}`, data),
-    error: (message: string, data?: Record<string, unknown>) =>
-      console.error(`[${tag}] ${message}`, data),
-    dispose: () => {},
-  };
 }

--- a/src/lib/host/logger.ts
+++ b/src/lib/host/logger.ts
@@ -2,7 +2,14 @@ import { LogLevel, type ILogger } from '../types';
 import { createConsoleLogger } from '../utils';
 import type * as vscode from 'vscode';
 
-export const disallowedLogKeys = ['password', 'secret', 'token', 'apiKey', 'apiSecret', 'content'];
+export const disallowedLogKeys: Set<string> = new Set([
+  'password',
+  'secret',
+  'token',
+  'apikey',
+  'apisecret',
+  'content',
+]);
 
 function removePromptsFromData<T>(dictionary: T | undefined | null): T | undefined {
   if (dictionary === null || dictionary === undefined) {
@@ -19,7 +26,7 @@ function removePromptsFromData<T>(dictionary: T | undefined | null): T | undefin
   try {
     const clone = structuredClone(dictionary) as Record<string, unknown>;
     for (const [key, value] of Object.entries(clone)) {
-      if (disallowedLogKeys.includes(key.toLowerCase())) {
+      if (disallowedLogKeys.has(key.toLowerCase())) {
         // eslint-disable-next-line @typescript-eslint/no-dynamic-delete
         delete clone[key];
         continue;
@@ -110,6 +117,9 @@ export const Logger: ILogger & {
    */
   {
     setOutputChannel: (outputChannel: vscode.OutputChannel | undefined) => {
+      if (LoggerImpl.outputChannel === outputChannel) {
+        return;
+      }
       LoggerImpl.dispose();
       LoggerImpl.outputChannel = outputChannel;
     },

--- a/src/lib/host/logger.ts
+++ b/src/lib/host/logger.ts
@@ -1,5 +1,6 @@
 import * as vscode from 'vscode';
 import { LogLevel, type ILogger } from '../types';
+import { createConsoleLogger } from '../client/useLogger';
 
 export const disallowedLogKeys = ['password', 'secret', 'token', 'apiKey', 'apiSecret', 'content'];
 
@@ -45,8 +46,9 @@ function removePromptsFromData<T>(dictionary: T | undefined | null): T | undefin
  */
 // eslint-disable-next-line @typescript-eslint/no-extraneous-class
 class LoggerImpl {
-  private static readonly outputChannel: vscode.OutputChannel =
-    vscode.window.createOutputChannel('IPC');
+  // eslint-disable-next-line sonarjs/public-static-readonly
+  static outputChannel: vscode.OutputChannel | undefined = undefined;
+  private static readonly consoleLogger = createConsoleLogger('RVW-IPC');
 
   public static debug(message: string, data: Record<string, unknown> | undefined = undefined) {
     this.log(LogLevel.DEBUG, message, data);
@@ -65,7 +67,7 @@ class LoggerImpl {
   }
 
   public static dispose() {
-    this.outputChannel.dispose();
+    this.outputChannel?.dispose();
   }
 
   private static log(level: LogLevel, message: string, data: Record<string, unknown> | undefined) {
@@ -73,25 +75,51 @@ class LoggerImpl {
     const levelStr = LogLevel[level] || 'UNKNOWN';
     const cleanedData = removePromptsFromData(data);
     const line = `[${timestamp}] [${levelStr}] ${message}`;
-    if (cleanedData === undefined) {
-      this.outputChannel.appendLine(line);
+    if (this.outputChannel === undefined) {
+      switch (level) {
+        case LogLevel.DEBUG: {
+          this.consoleLogger.debug(line, cleanedData);
+          break;
+        }
+        case LogLevel.INFO: {
+          this.consoleLogger.info(line, cleanedData);
+          break;
+        }
+        case LogLevel.WARN: {
+          this.consoleLogger.warn(line, cleanedData);
+          break;
+        }
+        case LogLevel.ERROR: {
+          this.consoleLogger.error(line, cleanedData);
+          break;
+        }
+      }
     } else {
-      try {
-        this.outputChannel.appendLine(`${line} : ${JSON.stringify(cleanedData)}`);
-      } catch {
-        this.outputChannel.appendLine(`${line} : unserializable data`);
+      if (cleanedData === undefined) {
+        this.outputChannel.appendLine(line);
+      } else {
+        try {
+          this.outputChannel.appendLine(`${line} : ${JSON.stringify(cleanedData)}`);
+        } catch {
+          this.outputChannel.appendLine(`${line} : unserializable data`);
+        }
       }
     }
   }
 }
 
-export const Logger: ILogger = {
-  debug: (message: string, data?: Record<string, unknown>) => LoggerImpl.debug(message, data),
-  info: (message: string, data?: Record<string, unknown>) => LoggerImpl.info(message, data),
-  warn: (message: string, data?: Record<string, unknown>) => LoggerImpl.warn(message, data),
-  error: (message: string, data?: Record<string, unknown>) => LoggerImpl.error(message, data),
-  dispose: () => LoggerImpl.dispose(),
-};
+export const Logger: ILogger & { setOutputChannel: (outputChannel: vscode.OutputChannel) => void } =
+  {
+    setOutputChannel: (outputChannel: vscode.OutputChannel) => {
+      LoggerImpl.dispose();
+      LoggerImpl.outputChannel = outputChannel;
+    },
+    debug: (message: string, data?: Record<string, unknown>) => LoggerImpl.debug(message, data),
+    info: (message: string, data?: Record<string, unknown>) => LoggerImpl.info(message, data),
+    warn: (message: string, data?: Record<string, unknown>) => LoggerImpl.warn(message, data),
+    error: (message: string, data?: Record<string, unknown>) => LoggerImpl.error(message, data),
+    dispose: () => LoggerImpl.dispose(),
+  };
 
 export const getLogger = (tag: string): ILogger => ({
   debug: (message: string, data?: Record<string, unknown>) =>

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -1,3 +1,6 @@
+/* eslint-disable no-console */
+import type { ILogger } from './types';
+
 /**
  * Generate a unique ID for requests
  */
@@ -7,4 +10,17 @@ export function generateId(prefix: string): string {
 }
 export function getErrorMessage(error: unknown): string {
   return error instanceof Error ? error.message : String(error);
+}
+export function createConsoleLogger(tag: string): ILogger {
+  return {
+    debug: (message: string, data?: Record<string, unknown>) =>
+      console.debug(`[${tag}] ${message}`, data),
+    info: (message: string, data?: Record<string, unknown>) =>
+      console.info(`[${tag}] ${message}`, data),
+    warn: (message: string, data?: Record<string, unknown>) =>
+      console.warn(`[${tag}] ${message}`, data),
+    error: (message: string, data?: Record<string, unknown>) =>
+      console.error(`[${tag}] ${message}`, data),
+    dispose: () => {},
+  };
 }

--- a/tests/lib/host.test.ts
+++ b/tests/lib/host.test.ts
@@ -10,7 +10,8 @@ describe('host module exports', () => {
 
     expect(typeof Logger).toBe('object');
     expect(typeof getLogger).toBe('function');
-    expect(Array.isArray(disallowedLogKeys)).toBe(true);
+    // Recent change: disallowedLogKeys is now a Set
+    expect(disallowedLogKeys instanceof Set).toBe(true);
   });
 
   it('should export WebviewApiProvider', async () => {
@@ -52,13 +53,13 @@ describe('host module exports', () => {
       expect(typeof logger.debug).toBe('function');
     });
 
-    it('should have disallowedLogKeys array with expected values', async () => {
+    it('should have disallowedLogKeys set with expected values', async () => {
       const { disallowedLogKeys } = await import('../../src/lib/host');
 
-      expect(disallowedLogKeys.length).toBeGreaterThan(0);
-      expect(disallowedLogKeys).toContain('password');
-      expect(disallowedLogKeys).toContain('token');
-      expect(disallowedLogKeys).toContain('secret');
+      expect(disallowedLogKeys.size).toBeGreaterThan(0);
+      expect(disallowedLogKeys.has('password')).toBe(true);
+      expect(disallowedLogKeys.has('token')).toBe(true);
+      expect(disallowedLogKeys.has('secret')).toBe(true);
     });
 
     it('should have working isViewApiRequest function', async () => {

--- a/tests/lib/host/logger.test.ts
+++ b/tests/lib/host/logger.test.ts
@@ -11,6 +11,9 @@ describe('host/logger', () => {
     mockOutputChannel.appendLine.mockClear();
     mockOutputChannel.dispose.mockClear();
 
+    // Route Logger output to the mocked VS Code output channel
+    Logger.setOutputChannel(mockOutputChannel);
+
     // Mock date for consistent timestamps
     originalDateNow = Date.prototype.toISOString;
     Date.prototype.toISOString = vi.fn(() => '2024-01-01T12:00:00.000Z');
@@ -19,6 +22,8 @@ describe('host/logger', () => {
   afterEach(() => {
     Date.prototype.toISOString = originalDateNow;
     vi.clearAllMocks();
+    // Reset output channel between tests
+    Logger.setOutputChannel(undefined);
   });
 
   describe('Logger static methods', () => {
@@ -320,14 +325,10 @@ describe('host/logger', () => {
 
   describe('disallowedLogKeys', () => {
     it('should export correct disallowed keys', () => {
-      expect(disallowedLogKeys).toEqual([
-        'password',
-        'secret',
-        'token',
-        'apiKey',
-        'apiSecret',
-        'content',
-      ]);
+      // Recent change: exported as Set with lowercase API keys
+      expect(disallowedLogKeys).toEqual(
+        new Set(['password', 'secret', 'token', 'apikey', 'apisecret', 'content'])
+      );
     });
   });
 


### PR DESCRIPTION
## Summary by Sourcery

Require explicit assignment of the logger output channel and add a console-based fallback logger.

New Features:
- Add setOutputChannel method to Logger for configuring the output channel.

Enhancements:
- Remove automatic creation of an OutputChannel and make it optional.
- Fallback to console logging via a shared consoleLogger when no output channel is set.
- Expose createConsoleLogger for external use.
- Guard disposal and JSON serialization to avoid errors when the output channel is undefined or data is unserializable.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* New Features
  * Added console-based fallback logging when an output channel isn’t set.
  * Exposed a console logger utility for external use.
  * Enabled switching the logging output channel at runtime.

* Bug Fixes
  * Prevented errors when no output channel is available.
  * Improved disposal handling of logging resources.
  * More resilient log formatting and serialization, avoiding failures on undefined or non-serializable data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Require explicit logger output channel setting, add console fallback, and enhance data sanitization.
> 
>   - **Logger Enhancements**:
>     - `Logger` now requires explicit `setOutputChannel()` to configure the output channel in `logger.ts`.
>     - Adds console-based fallback logging using `createConsoleLogger` in `utils.ts` when no output channel is set.
>     - `disallowedLogKeys` changed from array to `Set` for better performance.
>   - **Data Handling**:
>     - Improved data sanitization in `removePromptsFromData()` to handle nested objects and arrays.
>     - Handles unserializable data and circular references gracefully.
>   - **Testing**:
>     - Updated tests in `host.test.ts` and `logger.test.ts` to verify new logger behavior and data sanitization.
>     - Tests for `disallowedLogKeys` updated to reflect change to `Set`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=hbmartin%2Freact-vscode-webview-ipc&utm_source=github&utm_medium=referral)<sup> for 15e7253d284ea9dec4f2c7432407529c75ce7233. You can [customize](https://app.ellipsis.dev/hbmartin/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->