### PR TITLE
Add error handling and message queueing for hidden webviews

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ npm i react-vscode-webview-ipc
 
 - WebviewKey: a branded string identifying your view instance. Use a stable id (often your view type).
 - Messages:
-  - Reducer IPC: `{ type: 'act' }` messages from webview → host; `{ type: 'patch' }` messages from host → webview.
+  - Reducer IPC: `{ type: 'act' }` messages from webview → host; `{ type: 'patch' }` messages from host → webview; `{ type: 'actError' }` from host → webview when an action fails.
   - RPC IPC: `{ type: 'request' }` from webview → host; `{ type: 'response'|'error' }` from host → webview; `{ type: 'event' }` from host → webview broadcast.
 - Logging: webview logs are forwarded to the host’s Output channel.
 
@@ -41,16 +41,19 @@ Use this when your webview wants unidirectional state updates managed via a redu
 ### Types and Building Blocks
 
 - On the webview:
-  - `useVscodeState<S, A>(vscode, providerId, postReducer, initialState)` returns `[state, actor]`.
+  - `useVscodeState<S, A>(vscode, providerId, postReducer, initialState, options?)` returns `[state, actor]`.
     - `state: S` – your current state
     - `actor: A` – a proxy with methods matching your action interface
+    - `options.onError?: (error, actionKey?) => void` – called when a patch arrives for an unknown reducer key, or when the host reports that an action failed (defaults to `console.error`)
   - `postReducer: StateReducer<S, A>` maps each action key to `(prevState, patch) => newState`.
 - On the host:
   - Extend `BaseWebviewViewProvider<A>` and implement:
     - `webviewActionDelegate: ActionDelegate<A>` – map action keys to host handlers that return a patch (sync or async)
     - `generateWebviewHtml(webview, extensionUri)` – return the webview HTML
     - `handleMessage(message, webview)` – handle any messages you want besides reducer IPC (e.g., your RPC requests)
+  - If a delegate throws or rejects (or the action key is unknown), the error is logged and an `{ type: 'actError' }` message is posted back to the webview (surfaced through `useVscodeState`'s `onError`). Override `onActionError(key, error)` to add custom host-side handling.
   - Optionally pass a `WebviewApiProvider` instance to the base class constructor to enable host→webview event broadcasting (RPC paradigm).
+  - Optionally pass `BaseWebviewViewProviderOptions` as the 4th constructor argument: `{ queueHiddenMessages?: boolean; maxQueuedMessages?: number }`. By default, patches posted while the view is hidden (or not yet resolved) are queued (up to 100) and flushed when it becomes visible, instead of being silently dropped.
 
 ### Minimal Example
 
@@ -185,10 +188,16 @@ sequenceDiagram
   participant H as Extension Host
   W->>VS: postMessage { type: 'act', providerId, key, params }
   VS->>H: onDidReceiveMessage(message)
-  H->>H: webviewActionDelegate[key](...params) => patch
-  H-->>VS: postMessage { type: 'patch', providerId, key, patch }
-  VS-->>W: window message
-  W->>W: postReducer[key](prev, patch) => newState
+  alt success
+    H->>H: webviewActionDelegate[key](...params) => patch
+    H-->>VS: postMessage { type: 'patch', providerId, key, patch }
+    VS-->>W: window message
+    W->>W: postReducer[key](prev, patch) => newState
+  else delegate throws / unknown key
+    H-->>VS: postMessage { type: 'actError', providerId, key, error }
+    VS-->>W: window message
+    W->>W: options.onError(error, key)
+  end
 ```
 
 ## RPC Promises IPC (Typed Requests/Responses + Events)
@@ -203,10 +212,11 @@ Use this when your webview needs to call host functions and await results. The h
   - Call `const { api, addListener, removeListener, vscode } = useWebviewApi(ctxKey)` inside components.
     - `api.method(...)` returns a promise (typed from your `ClientCalls` interface).
     - `addListener('eventKey', cb)` / `removeListener(...)` manage host-pushed events.
+  - Requests time out (rejecting the promise) if the host never replies. The default is 30s (`DEFAULT_REQUEST_TIMEOUT_MS`); tune it with `<WebviewProvider requestTimeoutMs={5000}>`, or pass `0` to disable timeouts.
 - On the host:
   - Create a `WebviewApiProvider<HostEvents>()` and pass it to your `BaseWebviewViewProvider` constructor (to register views for events).
   - In your provider’s `handleMessage`, detect requests via `isViewApiRequest(message)`, dispatch to your host API handlers, and respond with `{ type: 'response'|'error', id, value }`.
-  - Use `apiProvider.triggerEvent('eventKey', ...args)` to broadcast events to connected webviews.
+  - Use `apiProvider.triggerEvent('eventKey', ...args)` to broadcast events to connected webviews. Events for hidden views are queued per view (up to 100 by default) and flushed when the view becomes visible; configure via `new WebviewApiProvider({ queueHiddenEvents, maxQueuedEvents })`.
 
 ### Minimal Example
 
@@ -375,7 +385,7 @@ sequenceDiagram
 
 - They are designed to coexist. The webview can dispatch reducer actions for state, and call RPC methods for imperative operations.
 - The library ensures messages don’t conflict:
-  - `useVscodeState` listens for `{ providerId, type: 'patch' }` messages.
+  - `useVscodeState` listens for `{ providerId, type: 'patch' }` and `{ providerId, type: 'actError' }` messages.
   - `WebviewProvider` listens for `{ type: 'response'|'error'|'event' }` messages and ignores messages with `providerId` present.
 - In your host provider, `resolveWebviewView` (from the base class) handles reducer `act/patch` automatically; implement `handleMessage` for RPC requests.
 
@@ -404,18 +414,25 @@ logger.info('hello');
 
 Host exports (`react-vscode-webview-ipc/host`):
 
-- `BaseWebviewViewProvider<A>`
-- `WebviewApiProvider<T extends HostCalls>`
+- `BaseWebviewViewProvider<A>` (constructor accepts `BaseWebviewViewProviderOptions` for hidden-view message queueing; override `onActionError(key, error)` to observe action failures)
+- `WebviewApiProvider<T extends HostCalls>` (constructor accepts `WebviewApiProviderOptions` for hidden-view event queueing)
 - `isViewApiRequest(message)`
 - `Logger`, `getLogger`, `disallowedLogKeys`
+- Types: `ActionDelegate`, `ActionError`, `BaseWebviewViewProviderOptions`, `WebviewApiProviderOptions`
 
 Client exports (`react-vscode-webview-ipc/client`):
 
-- `WebviewProvider<T extends ClientCalls>`
+- `WebviewProvider<T extends ClientCalls>` (accepts a `requestTimeoutMs` prop; `DEFAULT_REQUEST_TIMEOUT_MS` is 30s)
 - `useWebviewApi(ctxKey)` and `createCtxKey<T>()`
-- `useVscodeState<S, A>(vscode, providerId, postReducer, initial)`
+- `useVscodeState<S, A>(vscode, providerId, postReducer, initial, options?)`
 - `useLogger(tag, vscode)`
-- Types: `ClientCalls`, `HostCalls`, `CtxKey`, `WebviewKey`, `StateReducer`
+- Types: `ClientCalls`, `HostCalls`, `CtxKey`, `WebviewKey`, `StateReducer`, `UseVscodeStateOptions`
+
+## Robustness Behavior
+
+- RPC requests reject with a timeout error if the host never responds (default 30s, configurable per provider via `requestTimeoutMs`, disable with `0`), so pending promises can't leak.
+- Reducer action failures on the host (unknown action key, or a delegate that throws/rejects) are logged, reported to the provider's `onActionError` hook, and posted back to the webview as `{ type: 'actError' }` — surfaced via `useVscodeState`'s `onError` option. Message handlers never throw into the void.
+- Patches and events destined for hidden (or not-yet-resolved) webviews are queued — bounded, oldest-first eviction — and flushed automatically when the view becomes visible, instead of being silently dropped. Both queues can be disabled or resized via the constructor options above.
 
 ## References
 

--- a/src/lib/client.ts
+++ b/src/lib/client.ts
@@ -1,6 +1,6 @@
-export { WebviewProvider } from './client/WebviewProvider';
+export { WebviewProvider, DEFAULT_REQUEST_TIMEOUT_MS } from './client/WebviewProvider';
 export { createCtxKey, useWebviewApi } from './client/useWebviewApi';
-export { useVscodeState } from './client/useVscodeState';
+export { useVscodeState, type UseVscodeStateOptions } from './client/useVscodeState';
 export { useLogger } from './client/useLogger';
 export { isViewApiRequest, type CtxKey } from './types';
 export type { ClientCalls, HostCalls, ViewApiResponse, ViewApiError } from './types';

--- a/src/lib/client/WebviewProvider.tsx
+++ b/src/lib/client/WebviewProvider.tsx
@@ -20,10 +20,19 @@ declare function acquireVsCodeApi(): VsCodeApi;
 
 const vscodeApi = acquireVsCodeApi();
 
+/** Default timeout applied to RPC calls awaiting a host response. */
+// eslint-disable-next-line code-complete/no-magic-numbers-except-zero-one
+export const DEFAULT_REQUEST_TIMEOUT_MS = 30_000;
+
 interface WebviewProviderProps<T extends ClientCalls> {
   viewType: string;
   children: React.ReactNode;
   contextKey: CtxKey<T>;
+  /**
+   * Milliseconds to wait for a host response before rejecting an API call.
+   * Defaults to DEFAULT_REQUEST_TIMEOUT_MS (30s); pass 0 to disable timeouts.
+   */
+  requestTimeoutMs?: number;
 }
 
 /**
@@ -33,6 +42,7 @@ export const WebviewProvider = <T extends ClientCalls, H extends HostCalls>({
   children,
   viewType,
   contextKey,
+  requestTimeoutMs = DEFAULT_REQUEST_TIMEOUT_MS,
 }: WebviewProviderProps<T>) => {
   const pendingRequests = useRef<Map<string, DeferredPromise<any>>>(new Map());
   const listeners = useRef<Map<keyof HostCalls, Set<(...args: any[]) => void>>>(new Map());
@@ -64,6 +74,18 @@ export const WebviewProvider = <T extends ClientCalls, H extends HostCalls>({
     };
 
     pendingRequests.current.set(id, deferred);
+
+    // Reject if the host never replies (e.g. extension error, view disposed
+    // mid-flight) so the promise doesn't hang forever in pendingRequests
+    if (Number.isFinite(requestTimeoutMs) && requestTimeoutMs > 0) {
+      deferred.timeoutHandle = setTimeout(() => {
+        if (pendingRequests.current.delete(id)) {
+          deferred.reject(
+            new Error(`Request '${key as string}' timed out after ${String(requestTimeoutMs)}ms`)
+          );
+        }
+      }, requestTimeoutMs);
+    }
 
     // Send the request
     // eslint-disable-next-line sonarjs/no-try-promise
@@ -151,9 +173,10 @@ export const WebviewProvider = <T extends ClientCalls, H extends HostCalls>({
       } else if (message !== null && typeof message === 'object' && 'providerId' in message) {
         // No-op, handled by new IPC system
       } else {
-        // Handle legacy messages that don't follow the new format
-        // This ensures compatibility during migration
-        console.error('Received legacy message format:', message);
+        // Unrecognized window messages are expected (other scripts, other IPC
+        // systems, legacy formats), so keep this quiet
+        // eslint-disable-next-line no-console
+        console.debug('Received unrecognized message format:', message);
       }
     };
 

--- a/src/lib/client/useVscodeState.ts
+++ b/src/lib/client/useVscodeState.ts
@@ -1,9 +1,26 @@
 import { useCallback, useEffect, useMemo, useState } from 'react';
-import { ACT, type Patch, PATCH, type Action, type WebviewKey } from '../types/reducer';
+import {
+  ACT,
+  ACT_ERROR,
+  type ActionError,
+  type Patch,
+  PATCH,
+  type Action,
+  type WebviewKey,
+} from '../types/reducer';
 import { isFnKey } from './ipcReducer';
 import type { StateReducer, VsCodeApi } from './types';
 
 type PostAction<A extends object> = Pick<Action<A>, 'key' | 'params'>;
+
+export interface UseVscodeStateOptions {
+  /**
+   * Called when a patch arrives for an unknown reducer key, or when the host
+   * reports that an action failed (unknown key or a delegate threw/rejected).
+   * Defaults to logging via console.error.
+   */
+  onError?: (error: Error, actionKey?: string) => void;
+}
 
 function isMyPatchMessage<A extends object>(message: unknown, id: WebviewKey): message is Patch<A> {
   return (
@@ -20,13 +37,31 @@ function isMyPatchMessage<A extends object>(message: unknown, id: WebviewKey): m
   );
 }
 
+function isMyActionErrorMessage(message: unknown, id: WebviewKey): message is ActionError {
+  return (
+    message !== null &&
+    message !== undefined &&
+    typeof message === 'object' &&
+    'providerId' in message &&
+    'type' in message &&
+    'key' in message &&
+    'error' in message &&
+    message.type === ACT_ERROR &&
+    typeof message.key === 'string' &&
+    typeof message.error === 'string' &&
+    typeof message.providerId === 'string' &&
+    message.providerId === id
+  );
+}
+
 const dangerousKeys = new Set(['__proto__', 'constructor', 'prototype']);
 
 export function useVscodeState<S, A extends object>(
   vscode: VsCodeApi,
   providerId: WebviewKey,
   postReducer: StateReducer<S, A>,
-  initialState: S | (() => S)
+  initialState: S | (() => S),
+  options?: UseVscodeStateOptions
 ): readonly [S, A] {
   const [state, setState] = useState<S>(
     typeof initialState === 'function' ? (initialState as () => S)() : initialState
@@ -34,6 +69,18 @@ export function useVscodeState<S, A extends object>(
   const validKeys = useMemo(
     () => new Set(Object.keys(postReducer).filter((k) => !dangerousKeys.has(k))),
     [postReducer]
+  );
+
+  const onError = options?.onError;
+  const reportError = useCallback(
+    (error: Error, actionKey?: string) => {
+      if (onError === undefined) {
+        console.error(`[useVscodeState:${providerId}]`, error);
+      } else {
+        onError(error, actionKey);
+      }
+    },
+    [onError, providerId]
   );
 
   useEffect(() => {
@@ -48,15 +95,22 @@ export function useVscodeState<S, A extends object>(
           const patchFn = postReducer[data.key];
           setState((prev) => patchFn(prev, data.patch));
         } else {
-          throw new Error(`Could not find a function for ${String(data.key)} in postReducer`);
+          // Never throw inside a message handler: the exception would be
+          // uncatchable by the consumer. Report it instead.
+          reportError(
+            new Error(`Could not find a function for ${String(data.key)} in postReducer`),
+            String(data.key)
+          );
         }
+      } else if (isMyActionErrorMessage(data, providerId)) {
+        reportError(new Error(`Action '${data.key}' failed on the host: ${data.error}`), data.key);
       }
     };
     window.addEventListener('message', handler);
     return () => {
       window.removeEventListener('message', handler);
     };
-  }, [postReducer, providerId, validKeys]);
+  }, [postReducer, providerId, validKeys, reportError]);
 
   const postAction = useCallback(
     (arg: PostAction<A>) => {

--- a/src/lib/host.ts
+++ b/src/lib/host.ts
@@ -1,6 +1,9 @@
 export { Logger, getLogger, disallowedLogKeys } from './host/logger';
-export { WebviewApiProvider } from './host/WebviewApiProvider';
-export { BaseWebviewViewProvider } from './host/BaseWebviewViewProvider';
+export { WebviewApiProvider, type WebviewApiProviderOptions } from './host/WebviewApiProvider';
+export {
+  BaseWebviewViewProvider,
+  type BaseWebviewViewProviderOptions,
+} from './host/BaseWebviewViewProvider';
 export { isViewApiRequest } from './types';
 export type { ViewApiResponse, ViewApiError, ILogger } from './types';
-export type { ActionDelegate } from './types/reducer';
+export type { ActionDelegate, ActionError } from './types/reducer';

--- a/src/lib/host/BaseWebviewViewProvider.ts
+++ b/src/lib/host/BaseWebviewViewProvider.ts
@@ -1,8 +1,10 @@
 import * as vscode from 'vscode';
 import { type HostCalls, type ILogger, isLogMessage, LogLevel, type LogMessage } from '../types';
 import {
+  ACT_ERROR,
   PATCH,
   type ActionDelegate,
+  type ActionError,
   type FnKeys,
   type Patch,
   type Patches,
@@ -12,18 +14,39 @@ import { getLogger } from './logger';
 import { isMyActionMessage } from './utils';
 import type { WebviewApiProvider } from './WebviewApiProvider';
 
+export interface BaseWebviewViewProviderOptions {
+  /**
+   * When true (the default), patches and action errors posted while the
+   * webview is hidden (or not yet resolved) are queued and flushed when the
+   * view becomes visible, instead of being silently dropped by VS Code.
+   */
+  queueHiddenMessages?: boolean;
+  /** Maximum number of queued messages kept while hidden. Defaults to 100. */
+  maxQueuedMessages?: number;
+}
+
+// eslint-disable-next-line code-complete/no-magic-numbers-except-zero-one
+const DEFAULT_MAX_QUEUED_MESSAGES = 100;
+
 export abstract class BaseWebviewViewProvider<A extends object>
   implements vscode.WebviewViewProvider
 {
   protected _view?: vscode.WebviewView;
   protected readonly logger: ILogger;
+  private readonly queueHiddenMessages: boolean;
+  private readonly maxQueuedMessages: number;
+  private readonly outbox: (Patch<A> | ActionError)[] = [];
   protected abstract readonly webviewActionDelegate: ActionDelegate<A>;
+
   constructor(
     private readonly providerId: WebviewKey,
     private readonly extensionUri: vscode.Uri,
-    private readonly apiProvider?: WebviewApiProvider<HostCalls>
+    private readonly apiProvider?: WebviewApiProvider<HostCalls>,
+    options?: BaseWebviewViewProviderOptions
   ) {
     this.logger = getLogger(providerId.split('.')[1] ?? providerId);
+    this.queueHiddenMessages = options?.queueHiddenMessages ?? true;
+    this.maxQueuedMessages = options?.maxQueuedMessages ?? DEFAULT_MAX_QUEUED_MESSAGES;
   }
 
   public resolveWebviewView(
@@ -47,46 +70,54 @@ export abstract class BaseWebviewViewProvider<A extends object>
     this.apiProvider?.registerView(this.providerId, webviewView);
 
     const messageListener = webviewView.webview.onDidReceiveMessage(async (message) => {
-      if (isLogMessage(message)) {
-        this.handleLogMessage(message);
-        return;
+      // Never let an exception escape this callback: it would surface as an
+      // unhandled rejection that the consumer cannot catch.
+      try {
+        await this.dispatchMessage(message, webviewView.webview);
+      } catch (error) {
+        this.logger.error(
+          `Unhandled error while processing webview message: ${error instanceof Error ? error.message : String(error)}`
+        );
       }
-      if (isMyActionMessage<A>(message, this.providerId)) {
-        this.logger.debug('Received action message from webview', { message });
-
-        const delegateFn = this.webviewActionDelegate[message.key];
-        if (typeof delegateFn !== 'function') {
-          throw new TypeError(`Unknown action key: ${String(message.key)}`);
-        }
-
-        const patch = await delegateFn(...message.params);
-
-        this._view?.webview.postMessage({
-          type: PATCH,
-          providerId: this.providerId,
-          key: message.key,
-          patch,
-        });
-        return;
-      }
-
-      await this.handleMessage(message, webviewView.webview);
     });
 
-    // Dispose of the message listener when webview is disposed
+    const visibilityListener = webviewView.onDidChangeVisibility(() => {
+      if (webviewView.visible) {
+        this.flushOutbox();
+      }
+    });
+
+    // Dispose of the listeners when webview is disposed
     webviewView.onDidDispose(() => {
       messageListener.dispose();
+      visibilityListener.dispose();
+      if (this._view === webviewView) {
+        this._view = undefined;
+      }
       this.onWebviewDispose();
     });
+
+    // Deliver anything that was posted before the view was resolved
+    this.flushOutbox();
   }
 
   public postPatch<K extends FnKeys<A> = FnKeys<A>>(key: K, patch: Patches<A>[K]) {
-    this._view?.webview.postMessage({
+    this.postOrQueue({
       type: PATCH,
       providerId: this.providerId,
       key,
       patch,
     } satisfies Patch<A>);
+  }
+
+  /**
+   * Called when an action from the webview fails (unknown action key, or the
+   * delegate threw / rejected). The failure is already logged and reported to
+   * the webview as an `actError` message; override to add custom handling.
+   */
+  protected onActionError(_key: string, _error: Error): void {
+    // Default implementation does nothing
+    // Subclasses can override to observe action failures
   }
 
   /**
@@ -116,6 +147,104 @@ export abstract class BaseWebviewViewProvider<A extends object>
         this.logger.error(message.message, message.data);
         break;
       }
+    }
+  }
+
+  private async dispatchMessage(message: unknown, webview: vscode.Webview): Promise<void> {
+    if (isLogMessage(message)) {
+      this.handleLogMessage(message);
+      return;
+    }
+    if (isMyActionMessage<A>(message, this.providerId)) {
+      this.logger.debug('Received action message from webview', { message });
+
+      const delegateFn = this.webviewActionDelegate[message.key];
+      if (typeof delegateFn !== 'function') {
+        this.handleActionFailure(
+          String(message.key),
+          new TypeError(`Unknown action key: ${String(message.key)}`)
+        );
+        return;
+      }
+
+      try {
+        const patch = (await delegateFn(...message.params)) as Patches<A>[FnKeys<A>];
+        this.postOrQueue({
+          type: PATCH,
+          providerId: this.providerId,
+          key: message.key,
+          patch,
+        });
+      } catch (error) {
+        this.handleActionFailure(
+          String(message.key),
+          error instanceof Error ? error : new Error(String(error))
+        );
+      }
+      return;
+    }
+
+    await this.handleMessage(message, webview);
+  }
+
+  /**
+   * Logs a failed action, notifies `onActionError`, and posts an
+   * `{ type: 'actError' }` message so the webview learns the action failed.
+   */
+  private handleActionFailure(key: string, error: Error): void {
+    this.logger.error(`Action '${key}' failed: ${error.message}`);
+    this.onActionError(key, error);
+    this.postOrQueue({
+      type: ACT_ERROR,
+      providerId: this.providerId,
+      key,
+      error: error.message,
+    } satisfies ActionError);
+  }
+
+  private postOrQueue(message: Patch<A> | ActionError): void {
+    const view = this._view;
+    if (view?.visible === true) {
+      void Promise.resolve(view.webview.postMessage(message)).then(
+        (delivered) => {
+          if (!delivered) {
+            this.logger.warn(`Message of type '${message.type}' was not delivered to the webview`);
+          }
+        },
+        (error: unknown) => {
+          this.logger.error(
+            `Failed to post message of type '${message.type}' to the webview: ${error instanceof Error ? error.message : String(error)}`
+          );
+        }
+      );
+      return;
+    }
+
+    if (!this.queueHiddenMessages) {
+      this.logger.warn(
+        `Dropping message of type '${message.type}': webview is ${view === undefined ? 'not resolved' : 'hidden'}`
+      );
+      return;
+    }
+
+    if (this.outbox.length >= this.maxQueuedMessages) {
+      const dropped = this.outbox.shift();
+      this.logger.warn(
+        `Outbound queue is full (${String(this.maxQueuedMessages)}); dropping oldest message of type '${dropped?.type ?? 'unknown'}'`
+      );
+    }
+    this.outbox.push(message);
+  }
+
+  private flushOutbox(): void {
+    const view = this._view;
+    if (view?.visible !== true || this.outbox.length === 0) {
+      return;
+    }
+    const queued = this.outbox.splice(0);
+    this.logger.debug(`Flushing ${String(queued.length)} queued message(s) to the webview`);
+    for (const message of queued) {
+      this.postOrQueue(message);
     }
   }
 

--- a/src/lib/host/WebviewApiProvider.ts
+++ b/src/lib/host/WebviewApiProvider.ts
@@ -8,18 +8,41 @@ import type * as vscode from 'vscode';
  * WebviewApiProvider implements the type-safe API contract between host and webviews.
  * It handles all API calls and event dispatching with full type safety.
  */
-interface ConnectedView {
+interface ConnectedView<T extends HostCalls> {
   view: vscode.WebviewView;
   context: RequestContext;
+  pendingEvents: ViewApiEvent<T>[];
 }
 
+export interface WebviewApiProviderOptions {
+  /**
+   * When true (the default), events triggered while a webview is hidden are
+   * queued per view and flushed when the view becomes visible, instead of
+   * being silently dropped by VS Code.
+   */
+  queueHiddenEvents?: boolean;
+  /** Maximum number of queued events kept per hidden view. Defaults to 100. */
+  maxQueuedEvents?: number;
+}
+
+// eslint-disable-next-line code-complete/no-magic-numbers-except-zero-one
+const DEFAULT_MAX_QUEUED_EVENTS = 100;
+
 export class WebviewApiProvider<T extends HostCalls> implements vscode.Disposable {
-  private readonly connectedViews = new Map<WebviewKey, ConnectedView>();
+  private readonly connectedViews = new Map<WebviewKey, ConnectedView<T>>();
   private readonly disposables: vscode.Disposable[] = [];
   private readonly logger = getLogger('WebviewApiProvider');
+  private readonly queueHiddenEvents: boolean;
+  private readonly maxQueuedEvents: number;
+
+  constructor(options?: WebviewApiProviderOptions) {
+    this.queueHiddenEvents = options?.queueHiddenEvents ?? true;
+    this.maxQueuedEvents = options?.maxQueuedEvents ?? DEFAULT_MAX_QUEUED_EVENTS;
+  }
 
   /**
    * Type-safe event triggering to all connected webviews
+   * Events for hidden views are queued (see WebviewApiProviderOptions)
    * Prunes failing webviews to prevent unbounded growth and repeated failures
    */
   triggerEvent<E extends keyof T>(key: E, ...params: Parameters<T[E]>): void {
@@ -34,6 +57,11 @@ export class WebviewApiProvider<T extends HostCalls> implements vscode.Disposabl
 
     // Send to all connected views
     for (const [viewId, connectedView] of this.connectedViews.entries()) {
+      if (!connectedView.view.visible && this.queueHiddenEvents) {
+        this.enqueueEvent(connectedView, event, viewId);
+        continue;
+      }
+
       // eslint-disable-next-line sonarjs/no-try-promise
       try {
         const postPromise = connectedView.view.webview.postMessage(event);
@@ -100,11 +128,18 @@ export class WebviewApiProvider<T extends HostCalls> implements vscode.Disposabl
       sessionId: generateId('session'),
     };
 
-    this.connectedViews.set(id, { view, context });
+    this.connectedViews.set(id, { view, context, pendingEvents: [] });
     this.logger.info(`Registered webview: ${view.viewType}:${id}`);
+
+    const visibilityListener = view.onDidChangeVisibility(() => {
+      if (view.visible) {
+        this.flushPendingEvents(id);
+      }
+    });
 
     // Clean up on dispose
     view.onDidDispose(() => {
+      visibilityListener.dispose();
       this.connectedViews.delete(id);
       this.logger.info(`Unregistered webview: ${view.viewType}:${id}`);
     });
@@ -126,5 +161,53 @@ export class WebviewApiProvider<T extends HostCalls> implements vscode.Disposabl
     }
     this.connectedViews.clear();
     this.logger.info('WebviewApiProvider disposed');
+  }
+
+  private enqueueEvent(connectedView: ConnectedView<T>, event: ViewApiEvent<T>, viewId: string) {
+    if (connectedView.pendingEvents.length >= this.maxQueuedEvents) {
+      const dropped = connectedView.pendingEvents.shift();
+      this.logger.warn(
+        `Event queue for hidden view ${connectedView.context.viewType}:${viewId} is full (${String(this.maxQueuedEvents)}); dropping oldest event '${String(dropped?.key)}'`
+      );
+    }
+    connectedView.pendingEvents.push(event);
+  }
+
+  /**
+   * Flush events queued while a view was hidden
+   */
+  private flushPendingEvents(id: WebviewKey): void {
+    const connectedView = this.connectedViews.get(id);
+    if (
+      connectedView === undefined ||
+      !connectedView.view.visible ||
+      connectedView.pendingEvents.length === 0
+    ) {
+      return;
+    }
+
+    const queued = connectedView.pendingEvents.splice(0);
+    this.logger.debug(
+      `Flushing ${String(queued.length)} queued event(s) to view ${connectedView.context.viewType}:${id}`
+    );
+    for (const event of queued) {
+      // eslint-disable-next-line sonarjs/no-try-promise
+      try {
+        connectedView.view.webview.postMessage(event).then(
+          () => {
+            // Message sent successfully
+          },
+          (error: unknown) => {
+            this.logger.error(
+              `Failed to flush event ${String(event.key)} to view ${connectedView.context.viewType}:${id}: ${getErrorMessage(error)}`
+            );
+          }
+        );
+      } catch (error) {
+        this.logger.error(
+          `Exception while flushing event ${String(event.key)} to view ${connectedView.context.viewType}:${id}: ${String(error)}`
+        );
+      }
+    }
   }
 }

--- a/src/lib/types/reducer.ts
+++ b/src/lib/types/reducer.ts
@@ -3,6 +3,7 @@ import type { Brand } from '.';
 export type WebviewKey = Brand<string, 'WebviewKey'>;
 export const PATCH = 'patch';
 export const ACT = 'act';
+export const ACT_ERROR = 'actError';
 
 export type FnKeys<T> = {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -31,6 +32,16 @@ export interface Patch<A, K extends FnKeys<A> = FnKeys<A>> extends IpcMessage {
   readonly type: typeof PATCH;
   readonly key: K;
   readonly patch: Patches<A>[K];
+}
+
+/**
+ * Sent from host → webview when an action could not be handled
+ * (unknown action key, or the delegate threw / rejected).
+ */
+export interface ActionError extends IpcMessage {
+  readonly type: typeof ACT_ERROR;
+  readonly key: string;
+  readonly error: string;
 }
 
 export type Patches<A> = {

--- a/tests/lib/client/WebviewProvider.test.tsx
+++ b/tests/lib/client/WebviewProvider.test.tsx
@@ -1,0 +1,173 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { act, render } from '@testing-library/react';
+import {
+  DEFAULT_REQUEST_TIMEOUT_MS,
+  WebviewProvider,
+} from '../../../src/lib/client/WebviewProvider';
+import { createCtxKey, useWebviewApi } from '../../../src/lib/client/useWebviewApi';
+import { mockVsCodeApi } from '../../setup/vitest.setup';
+import type { ClientCalls } from '../../../src/lib/types';
+
+interface TestCalls extends ClientCalls {
+  testMethod: (arg: string) => Promise<string>;
+}
+
+function renderProvider(requestTimeoutMs?: number) {
+  const contextKey = createCtxKey<TestCalls>('test');
+  let api: ReturnType<typeof useWebviewApi<TestCalls>>['api'] | undefined;
+
+  function Capture() {
+    api = useWebviewApi(contextKey).api;
+    return null;
+  }
+
+  render(
+    <WebviewProvider
+      viewType="test.view"
+      contextKey={contextKey}
+      requestTimeoutMs={requestTimeoutMs}
+    >
+      <Capture />
+    </WebviewProvider>
+  );
+
+  if (api === undefined) {
+    throw new Error('api was not captured');
+  }
+  return api;
+}
+
+function lastPostedRequest(): { id: string } {
+  const call = mockVsCodeApi.postMessage.mock.calls.at(-1);
+  if (call === undefined) {
+    throw new Error('no request was posted');
+  }
+  return call[0] as { id: string };
+}
+
+describe('WebviewProvider request timeouts', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('should reject a pending request after the default timeout', async () => {
+    const api = renderProvider();
+
+    const promise = api.testMethod('hello');
+    const rejection = expect(promise).rejects.toThrow(
+      `Request 'testMethod' timed out after ${DEFAULT_REQUEST_TIMEOUT_MS}ms`
+    );
+
+    act(() => {
+      vi.advanceTimersByTime(DEFAULT_REQUEST_TIMEOUT_MS);
+    });
+
+    await rejection;
+  });
+
+  it('should reject after a custom provider-level timeout', async () => {
+    const api = renderProvider(100);
+
+    const promise = api.testMethod('hello');
+    const rejection = expect(promise).rejects.toThrow("Request 'testMethod' timed out after 100ms");
+
+    act(() => {
+      vi.advanceTimersByTime(100);
+    });
+
+    await rejection;
+  });
+
+  it('should not time out when requestTimeoutMs is 0', async () => {
+    const api = renderProvider(0);
+
+    let settled = false;
+    const promise = api.testMethod('hello');
+    promise.then(
+      () => {
+        settled = true;
+      },
+      () => {
+        settled = true;
+      }
+    );
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(DEFAULT_REQUEST_TIMEOUT_MS * 10);
+    });
+
+    expect(settled).toBe(false);
+  });
+
+  it('should resolve normally and not fire the timeout when a response arrives', async () => {
+    const api = renderProvider();
+
+    const promise = api.testMethod('hello');
+    const request = lastPostedRequest();
+
+    act(() => {
+      window.dispatchEvent(
+        new MessageEvent('message', {
+          data: { type: 'response', id: request.id, value: 'result' },
+        })
+      );
+    });
+
+    await expect(promise).resolves.toBe('result');
+
+    // Advancing past the timeout must not produce a late rejection
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(DEFAULT_REQUEST_TIMEOUT_MS * 2);
+    });
+  });
+
+  it('should reject with the host error and not fire the timeout when an error arrives', async () => {
+    const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => undefined);
+    const api = renderProvider();
+
+    const promise = api.testMethod('hello');
+    const request = lastPostedRequest();
+    const rejection = expect(promise).rejects.toThrow('host failed');
+
+    act(() => {
+      window.dispatchEvent(
+        new MessageEvent('message', {
+          data: { type: 'error', id: request.id, value: 'host failed' },
+        })
+      );
+    });
+
+    await rejection;
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(DEFAULT_REQUEST_TIMEOUT_MS * 2);
+    });
+    consoleSpy.mockRestore();
+  });
+});
+
+describe('WebviewProvider unrecognized message handling', () => {
+  it('should log unrecognized window messages at debug level, not error', () => {
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => undefined);
+    const debugSpy = vi.spyOn(console, 'debug').mockImplementation(() => undefined);
+
+    renderProvider();
+
+    act(() => {
+      window.dispatchEvent(new MessageEvent('message', { data: { source: 'some-other-script' } }));
+    });
+
+    expect(errorSpy).not.toHaveBeenCalled();
+    expect(debugSpy).toHaveBeenCalledWith(
+      'Received unrecognized message format:',
+      expect.objectContaining({ source: 'some-other-script' })
+    );
+
+    errorSpy.mockRestore();
+    debugSpy.mockRestore();
+  });
+});

--- a/tests/lib/client/useVscodeState.test.ts
+++ b/tests/lib/client/useVscodeState.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { renderHook, act } from '@testing-library/react';
 import { useVscodeState } from '../../../src/lib/client/useVscodeState';
-import { PATCH, ACT, type WebviewKey } from '../../../src/lib/types/reducer';
+import { PATCH, ACT, ACT_ERROR, type WebviewKey } from '../../../src/lib/types/reducer';
 import type { StateReducer, VsCodeApi } from '../../../src/lib/client/types';
 
 // Test interfaces
@@ -288,7 +288,8 @@ describe('useVscodeState', () => {
       expect(state.count).toBe(0); // Should not change
     });
 
-    it('should throw error for unknown reducer key in patch', () => {
+    it('should not throw for unknown reducer key in patch and log an error', () => {
+      const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => undefined);
       renderHook(() => useVscodeState(mockVscode, providerId, postReducer, initialState));
 
       const patchMessage = {
@@ -302,7 +303,91 @@ describe('useVscodeState', () => {
         act(() => {
           messageListeners[0](new MessageEvent('message', { data: patchMessage }));
         });
-      }).toThrow('Could not find a function for unknownKey in postReducer');
+      }).not.toThrow();
+
+      expect(consoleSpy).toHaveBeenCalledWith(
+        expect.stringContaining('useVscodeState'),
+        expect.objectContaining({
+          message: 'Could not find a function for unknownKey in postReducer',
+        })
+      );
+      consoleSpy.mockRestore();
+    });
+
+    it('should report unknown reducer key to onError callback when provided', () => {
+      const onError = vi.fn();
+      renderHook(() =>
+        useVscodeState(mockVscode, providerId, postReducer, initialState, { onError })
+      );
+
+      act(() => {
+        messageListeners[0](
+          new MessageEvent('message', {
+            data: {
+              type: PATCH,
+              providerId: 'test.provider',
+              key: 'unknownKey',
+              patch: undefined,
+            },
+          })
+        );
+      });
+
+      expect(onError).toHaveBeenCalledWith(
+        expect.objectContaining({
+          message: 'Could not find a function for unknownKey in postReducer',
+        }),
+        'unknownKey'
+      );
+    });
+
+    it('should report host action errors to onError callback', () => {
+      const onError = vi.fn();
+      renderHook(() =>
+        useVscodeState(mockVscode, providerId, postReducer, initialState, { onError })
+      );
+
+      act(() => {
+        messageListeners[0](
+          new MessageEvent('message', {
+            data: {
+              type: ACT_ERROR,
+              providerId: 'test.provider',
+              key: 'increment',
+              error: 'delegate failed',
+            },
+          })
+        );
+      });
+
+      expect(onError).toHaveBeenCalledWith(
+        expect.objectContaining({
+          message: "Action 'increment' failed on the host: delegate failed",
+        }),
+        'increment'
+      );
+    });
+
+    it('should ignore action errors from other providers', () => {
+      const onError = vi.fn();
+      renderHook(() =>
+        useVscodeState(mockVscode, providerId, postReducer, initialState, { onError })
+      );
+
+      act(() => {
+        messageListeners[0](
+          new MessageEvent('message', {
+            data: {
+              type: ACT_ERROR,
+              providerId: 'other.provider',
+              key: 'increment',
+              error: 'delegate failed',
+            },
+          })
+        );
+      });
+
+      expect(onError).not.toHaveBeenCalled();
     });
 
     it('should handle multiple patch messages', () => {

--- a/tests/lib/host/BaseWebviewViewProvider.test.ts
+++ b/tests/lib/host/BaseWebviewViewProvider.test.ts
@@ -1,6 +1,11 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { BaseWebviewViewProvider } from '../../../src/lib/host/BaseWebviewViewProvider';
-import { type ActionDelegate, type WebviewKey, PATCH } from '../../../src/lib/types/reducer';
+import {
+  type ActionDelegate,
+  type WebviewKey,
+  ACT_ERROR,
+  PATCH,
+} from '../../../src/lib/types/reducer';
 import { LogLevel } from '../../../src/lib/types';
 import type { WebviewApiProvider } from '../../../src/lib/host/WebviewApiProvider';
 import type * as vscode from 'vscode';
@@ -52,6 +57,7 @@ describe('BaseWebviewViewProvider', () => {
   let mockApiProvider: WebviewApiProvider<any>;
   let messageCallback: (message: any) => void;
   let disposeCallback: () => void;
+  let visibilityCallback: () => void;
 
   beforeEach(() => {
     vi.clearAllMocks();
@@ -75,7 +81,10 @@ describe('BaseWebviewViewProvider', () => {
       description: undefined,
       badge: undefined,
       show: vi.fn(),
-      onDidChangeVisibility: vi.fn(() => ({ dispose: vi.fn() })),
+      onDidChangeVisibility: vi.fn((callback: () => void) => {
+        visibilityCallback = callback;
+        return { dispose: vi.fn() };
+      }),
       onDidDispose: vi.fn((callback: () => void) => {
         disposeCallback = callback;
         return { dispose: vi.fn() };
@@ -200,7 +209,7 @@ describe('BaseWebviewViewProvider', () => {
       });
     });
 
-    it('should throw error for unknown action key', async () => {
+    it('should not throw for unknown action key and post an actError message', async () => {
       const actionMessage = {
         type: 'act',
         providerId: 'test.provider',
@@ -208,9 +217,67 @@ describe('BaseWebviewViewProvider', () => {
         params: [],
       };
 
-      await expect(messageCallback(actionMessage)).rejects.toThrow(
-        'Unknown action key: unknownMethod'
+      const loggerSpy = vi.spyOn(provider['logger'], 'error');
+      await expect(messageCallback(actionMessage)).resolves.toBeUndefined();
+
+      expect(loggerSpy).toHaveBeenCalledWith(
+        expect.stringContaining('Unknown action key: unknownMethod')
       );
+      expect(mockWebview.postMessage).toHaveBeenCalledWith({
+        type: ACT_ERROR,
+        providerId: 'test.provider',
+        key: 'unknownMethod',
+        error: 'Unknown action key: unknownMethod',
+      });
+    });
+
+    it('should handle rejecting action delegates without unhandled rejection', async () => {
+      const failure = new Error('delegate blew up');
+      (provider['webviewActionDelegate'].fetchData as any).mockRejectedValueOnce(failure);
+
+      const loggerSpy = vi.spyOn(provider['logger'], 'error');
+      const actionMessage = {
+        type: 'act',
+        providerId: 'test.provider',
+        key: 'fetchData',
+        params: ['123'],
+      };
+
+      await expect(messageCallback(actionMessage)).resolves.toBeUndefined();
+
+      expect(loggerSpy).toHaveBeenCalledWith(
+        expect.stringContaining("Action 'fetchData' failed: delegate blew up")
+      );
+      expect(mockWebview.postMessage).toHaveBeenCalledWith({
+        type: ACT_ERROR,
+        providerId: 'test.provider',
+        key: 'fetchData',
+        error: 'delegate blew up',
+      });
+    });
+
+    it('should invoke onActionError hook when a delegate fails', async () => {
+      const failure = new Error('nope');
+      (provider['webviewActionDelegate'].fetchData as any).mockRejectedValueOnce(failure);
+      const hookSpy = vi.spyOn(provider as any, 'onActionError');
+
+      await messageCallback({
+        type: 'act',
+        providerId: 'test.provider',
+        key: 'fetchData',
+        params: ['123'],
+      });
+
+      expect(hookSpy).toHaveBeenCalledWith('fetchData', failure);
+    });
+
+    it('should not propagate rejections from handleMessage', async () => {
+      provider.handleMessage.mockRejectedValueOnce(new Error('consumer handler failed'));
+      const loggerSpy = vi.spyOn(provider['logger'], 'error');
+
+      await expect(messageCallback({ type: 'custom' })).resolves.toBeUndefined();
+
+      expect(loggerSpy).toHaveBeenCalledWith(expect.stringContaining('consumer handler failed'));
     });
 
     it('should call handleMessage for other messages', async () => {
@@ -244,6 +311,104 @@ describe('BaseWebviewViewProvider', () => {
       expect(() => {
         newProvider.postPatch('fetchData', { data: 'test' });
       }).not.toThrow();
+    });
+  });
+
+  describe('hidden webview message queueing', () => {
+    it('should queue patches while the view is hidden and flush when visible again', () => {
+      provider.resolveWebviewView(mockWebviewView, {} as any, {} as any);
+
+      mockWebviewView.visible = false;
+      provider.postPatch('fetchData', { data: 'while hidden' });
+
+      expect(mockWebview.postMessage).not.toHaveBeenCalled();
+
+      mockWebviewView.visible = true;
+      visibilityCallback();
+
+      expect(mockWebview.postMessage).toHaveBeenCalledWith({
+        type: PATCH,
+        providerId: 'test.provider',
+        key: 'fetchData',
+        patch: { data: 'while hidden' },
+      });
+    });
+
+    it('should queue patches posted before the view is resolved and flush on resolve', () => {
+      provider.postPatch('fetchData', { data: 'before resolve' });
+      expect(mockWebview.postMessage).not.toHaveBeenCalled();
+
+      provider.resolveWebviewView(mockWebviewView, {} as any, {} as any);
+
+      expect(mockWebview.postMessage).toHaveBeenCalledWith({
+        type: PATCH,
+        providerId: 'test.provider',
+        key: 'fetchData',
+        patch: { data: 'before resolve' },
+      });
+    });
+
+    it('should preserve message order when flushing', () => {
+      provider.resolveWebviewView(mockWebviewView, {} as any, {} as any);
+
+      mockWebviewView.visible = false;
+      provider.postPatch('fetchData', { data: 'first' });
+      provider.postPatch('fetchData', { data: 'second' });
+
+      mockWebviewView.visible = true;
+      visibilityCallback();
+
+      const patches = mockWebview.postMessage.mock.calls.map((call: any[]) => call[0].patch);
+      expect(patches).toEqual([{ data: 'first' }, { data: 'second' }]);
+    });
+
+    it('should drop the oldest message when the queue is full', () => {
+      const boundedProvider = new TestWebviewProvider(
+        'test.provider' as WebviewKey,
+        mockExtensionUri,
+        mockApiProvider,
+        { maxQueuedMessages: 2 }
+      );
+      boundedProvider.resolveWebviewView(mockWebviewView, {} as any, {} as any);
+
+      mockWebviewView.visible = false;
+      boundedProvider.postPatch('fetchData', { data: 'one' });
+      boundedProvider.postPatch('fetchData', { data: 'two' });
+      boundedProvider.postPatch('fetchData', { data: 'three' });
+
+      mockWebviewView.visible = true;
+      visibilityCallback();
+
+      const patches = mockWebview.postMessage.mock.calls.map((call: any[]) => call[0].patch);
+      expect(patches).toEqual([{ data: 'two' }, { data: 'three' }]);
+    });
+
+    it('should drop messages while hidden when queueing is disabled', () => {
+      const nonQueueingProvider = new TestWebviewProvider(
+        'test.provider' as WebviewKey,
+        mockExtensionUri,
+        mockApiProvider,
+        { queueHiddenMessages: false }
+      );
+      nonQueueingProvider.resolveWebviewView(mockWebviewView, {} as any, {} as any);
+
+      mockWebviewView.visible = false;
+      nonQueueingProvider.postPatch('fetchData', { data: 'dropped' });
+
+      mockWebviewView.visible = true;
+      visibilityCallback();
+
+      expect(mockWebview.postMessage).not.toHaveBeenCalled();
+    });
+
+    it('should stop posting to a disposed view and queue instead', () => {
+      provider.resolveWebviewView(mockWebviewView, {} as any, {} as any);
+      disposeCallback();
+
+      expect(() => {
+        provider.postPatch('fetchData', { data: 'after dispose' });
+      }).not.toThrow();
+      expect(mockWebview.postMessage).not.toHaveBeenCalled();
     });
   });
 

--- a/tests/lib/host/WebviewApiProvider.test.ts
+++ b/tests/lib/host/WebviewApiProvider.test.ts
@@ -206,6 +206,103 @@ describe('WebviewApiProvider', () => {
     });
   });
 
+  describe('hidden view event queueing', () => {
+    function createHiddenView() {
+      let visibilityCallback: (() => void) | undefined;
+      const view: any = {
+        ...mockWebviewView,
+        viewType: 'hiddenView',
+        visible: false,
+        webview: {
+          ...mockWebviewView.webview,
+          postMessage: vi.fn().mockResolvedValue(true),
+        },
+        onDidChangeVisibility: vi.fn((callback: () => void) => {
+          visibilityCallback = callback;
+          return { dispose: vi.fn() };
+        }),
+        onDidDispose: vi.fn(() => ({ dispose: vi.fn() })),
+      };
+      return {
+        view,
+        show: () => {
+          view.visible = true;
+          visibilityCallback?.();
+        },
+      };
+    }
+
+    it('should queue events for hidden views instead of posting', () => {
+      const { view } = createHiddenView();
+      provider.registerView(createWebviewKey('hidden-view'), view);
+
+      provider.triggerEvent('onDataUpdate', { data: 'while hidden' });
+
+      expect(view.webview.postMessage).not.toHaveBeenCalled();
+      expect(provider.getConnectedViewCount()).toBe(1);
+    });
+
+    it('should flush queued events in order when the view becomes visible', () => {
+      const { view, show } = createHiddenView();
+      provider.registerView(createWebviewKey('hidden-view'), view);
+
+      provider.triggerEvent('onDataUpdate', { data: 'first' });
+      provider.triggerEvent('onUserAction', 'click', { x: 1 });
+
+      show();
+
+      expect(view.webview.postMessage).toHaveBeenCalledTimes(2);
+      expect(view.webview.postMessage).toHaveBeenNthCalledWith(1, {
+        type: 'event',
+        key: 'onDataUpdate',
+        value: [{ data: 'first' }],
+      });
+      expect(view.webview.postMessage).toHaveBeenNthCalledWith(2, {
+        type: 'event',
+        key: 'onUserAction',
+        value: ['click', { x: 1 }],
+      });
+    });
+
+    it('should drop the oldest event when the per-view queue is full', () => {
+      const boundedProvider = new WebviewApiProvider<TestHostCalls>({ maxQueuedEvents: 2 });
+      const { view, show } = createHiddenView();
+      boundedProvider.registerView(createWebviewKey('hidden-view'), view);
+
+      boundedProvider.triggerEvent('onDataUpdate', { data: 'one' });
+      boundedProvider.triggerEvent('onDataUpdate', { data: 'two' });
+      boundedProvider.triggerEvent('onDataUpdate', { data: 'three' });
+
+      show();
+
+      expect(view.webview.postMessage).toHaveBeenCalledTimes(2);
+      const values = view.webview.postMessage.mock.calls.map((call: any[]) => call[0].value);
+      expect(values).toEqual([[{ data: 'two' }], [{ data: 'three' }]]);
+      boundedProvider.dispose();
+    });
+
+    it('should post directly to hidden views when queueing is disabled', () => {
+      const nonQueueingProvider = new WebviewApiProvider<TestHostCalls>({
+        queueHiddenEvents: false,
+      });
+      const { view } = createHiddenView();
+      nonQueueingProvider.registerView(createWebviewKey('hidden-view'), view);
+
+      nonQueueingProvider.triggerEvent('onDataUpdate', { data: 'test' });
+
+      expect(view.webview.postMessage).toHaveBeenCalledTimes(1);
+      nonQueueingProvider.dispose();
+    });
+
+    it('should still post immediately to visible views', () => {
+      provider.registerView(createWebviewKey('visible-view'), mockWebviewView);
+
+      provider.triggerEvent('onDataUpdate', { data: 'test' });
+
+      expect(mockWebviewView.webview.postMessage).toHaveBeenCalledTimes(1);
+    });
+  });
+
   describe('getConnectedViewCount', () => {
     it('should return 0 when no views are connected', () => {
       expect(provider.getConnectedViewCount()).toBe(0);


### PR DESCRIPTION
## Summary

This PR adds robust error handling for failed actions and implements message queueing for hidden webviews across both the host and client sides. When webviews are hidden or not yet resolved, patches and action errors are now queued and flushed when the view becomes visible, preventing silent message loss. Additionally, action failures are now properly reported back to the webview instead of throwing unhandled exceptions.

## Key Changes

### Host-side improvements (`BaseWebviewViewProvider`)
- **Error handling**: Action failures (unknown keys or delegate exceptions) are now caught and reported via a new `{ type: 'actError' }` message instead of throwing unhandled exceptions
- **Message queueing**: Patches and action errors posted while the webview is hidden or unresolved are queued per-view and flushed when visible
- **Configuration**: New `BaseWebviewViewProviderOptions` interface allows customizing queue behavior (`queueHiddenMessages`, `maxQueuedMessages`)
- **Visibility tracking**: Added listener for `onDidChangeVisibility` to flush queued messages when views become visible
- **Error callback**: New `onActionError(key, error)` hook allows subclasses to observe action failures

### Host API provider improvements (`WebviewApiProvider`)
- **Event queueing**: Events triggered while webviews are hidden are now queued per-view instead of being silently dropped
- **Configuration**: New `WebviewApiProviderOptions` interface for controlling event queueing behavior (`queueHiddenEvents`, `maxQueuedEvents`)
- **Visibility tracking**: Listens to view visibility changes to flush pending events

### Client-side improvements (`useVscodeState`)
- **Error reporting**: New `onError` callback in `UseVscodeStateOptions` allows consumers to handle patch errors and action failures
- **Action error handling**: Recognizes and processes `{ type: 'actError' }` messages from the host
- **Error propagation**: Errors are reported via callback instead of throwing, preventing unhandled rejections

### Request timeout handling (`WebviewProvider`)
- **Configurable timeouts**: New `requestTimeoutMs` prop allows customizing RPC request timeouts (defaults to 30s, can be disabled with 0)
- **Timeout rejection**: Pending requests are properly rejected if the host doesn't respond within the timeout window
- **Error handling**: Unrecognized messages are logged at debug level instead of error level

## Implementation Details

- Message handlers are wrapped in try-catch blocks to prevent unhandled rejections from escaping
- Queues have configurable maximum sizes with FIFO eviction when full
- Message order is preserved when flushing queues
- All queue operations are logged for debugging visibility
- The implementation maintains backward compatibility with sensible defaults (queueing enabled, 100-message limit)

https://claude.ai/code/session_01TDwxXmBris8stySErruvQV

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/hbmartin/react-vscode-webview-ipc/pull/9?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for configurable timeouts on API requests.
  * Added optional queuing for messages and events while a webview is hidden, with automatic delivery when it becomes visible.
  * Added clearer error reporting for failed actions, including a new host-to-webview error message path.

* **Bug Fixes**
  * Improved handling of unknown or failed action messages so they no longer surface as unhandled errors.
  * Updated hidden-view behavior to preserve message order and drop the oldest queued items when limits are reached.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->