### PR TITLE
[codex] Address webview robustness follow-ups

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # React + VSCode Webview = IPC
 
-[![npm version](https://badge.fury.io/js/react-vscode-webview-ipc.svg)](https://www.npmjs.com/package/react-vscode-webview-ipc)
+[![npm version](https://img.shields.io/npm/v/react-vscode-webview-ipc?color=green)](https://www.npmjs.com/package/react-vscode-webview-ipc)
 [![Ask DeepWiki](https://deepwiki.com/badge.svg)](https://deepwiki.com/hbmartin/react-vscode-webview-ipc)
 [![CI](https://github.com/hbmartin/react-vscode-webview-ipc/actions/workflows/ci.yml/badge.svg)](https://github.com/hbmartin/react-vscode-webview-ipc/actions/workflows/ci.yml)
 [![NPM License](https://img.shields.io/npm/l/react-vscode-webview-ipc?color=blue)](https://github.com/hbmartin/react-vscode-webview-ipc/blob/main/LICENSE.txt)
@@ -430,7 +430,7 @@ Client exports (`react-vscode-webview-ipc/client`):
 
 ## Robustness Behavior
 
-- RPC requests reject with a timeout error if the host never responds (default 30s, configurable per provider via `requestTimeoutMs`, disable with `0`), so pending promises can't leak.
+- RPC requests reject with a timeout error if the host never responds when timeouts are enabled (default 30s, configurable per provider via `requestTimeoutMs`, disable with `0`), bounding pending promises for the enabled case.
 - Reducer action failures on the host (unknown action key, or a delegate that throws/rejects) are logged, reported to the provider's `onActionError` hook, and posted back to the webview as `{ type: 'actError' }` — surfaced via `useVscodeState`'s `onError` option. Message handlers never throw into the void.
 - Patches and events destined for hidden (or not-yet-resolved) webviews are queued — bounded, oldest-first eviction — and flushed automatically when the view becomes visible, instead of being silently dropped. Both queues can be disabled or resized via the constructor options above.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "react-vscode-webview-ipc",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "react-vscode-webview-ipc",
-      "version": "0.1.0",
+      "version": "0.1.1",
       "license": "Apache-2.0",
       "devDependencies": {
         "@eslint/js": "^9.33.0",

--- a/src/lib/client/WebviewProvider.tsx
+++ b/src/lib/client/WebviewProvider.tsx
@@ -18,6 +18,7 @@ import type { WebviewContextValue } from './WebviewContext';
 
 declare function acquireVsCodeApi(): VsCodeApi;
 
+// TODO: option to allow vsdcode api to be passed in to component
 const vscodeApi = acquireVsCodeApi();
 
 /** Default timeout applied to RPC calls awaiting a host response. */

--- a/src/lib/host/BaseWebviewViewProvider.ts
+++ b/src/lib/host/BaseWebviewViewProvider.ts
@@ -36,6 +36,7 @@ export abstract class BaseWebviewViewProvider<A extends object>
   private readonly queueHiddenMessages: boolean;
   private readonly maxQueuedMessages: number;
   private readonly outbox: (Patch<A> | ActionError)[] = [];
+  private hasResolvedView = false;
   protected abstract readonly webviewActionDelegate: ActionDelegate<A>;
 
   constructor(
@@ -56,6 +57,7 @@ export abstract class BaseWebviewViewProvider<A extends object>
   ): Thenable<void> | void {
     this.logger.debug('Resolving webview view');
     this._view = webviewView;
+    this.hasResolvedView = true;
 
     webviewView.webview.options = {
       enableScripts: true,
@@ -93,6 +95,7 @@ export abstract class BaseWebviewViewProvider<A extends object>
       visibilityListener.dispose();
       if (this._view === webviewView) {
         this._view = undefined;
+        this.outbox.length = 0;
       }
       this.onWebviewDispose();
     });
@@ -193,7 +196,13 @@ export abstract class BaseWebviewViewProvider<A extends object>
    */
   private handleActionFailure(key: string, error: Error): void {
     this.logger.error(`Action '${key}' failed: ${error.message}`);
-    this.onActionError(key, error);
+    try {
+      this.onActionError(key, error);
+    } catch (hookError) {
+      this.logger.error(
+        `onActionError hook failed for action '${key}': ${hookError instanceof Error ? hookError.message : String(hookError)}`
+      );
+    }
     this.postOrQueue({
       type: ACT_ERROR,
       providerId: this.providerId,
@@ -223,6 +232,18 @@ export abstract class BaseWebviewViewProvider<A extends object>
     if (!this.queueHiddenMessages) {
       this.logger.warn(
         `Dropping message of type '${message.type}': webview is ${view === undefined ? 'not resolved' : 'hidden'}`
+      );
+      return;
+    }
+
+    if (view === undefined && this.hasResolvedView) {
+      this.logger.warn(`Dropping message of type '${message.type}': webview is disposed`);
+      return;
+    }
+
+    if (this.maxQueuedMessages <= 0) {
+      this.logger.warn(
+        `Dropping message of type '${message.type}': maxQueuedMessages is ${String(this.maxQueuedMessages)}`
       );
       return;
     }

--- a/src/lib/host/WebviewApiProvider.ts
+++ b/src/lib/host/WebviewApiProvider.ts
@@ -52,9 +52,6 @@ export class WebviewApiProvider<T extends HostCalls> implements vscode.Disposabl
       value: params,
     };
 
-    // Track views that fail to receive messages
-    const failedViews: string[] = [];
-
     // Send to all connected views
     for (const [viewId, connectedView] of this.connectedViews.entries()) {
       if (!connectedView.view.visible && this.queueHiddenEvents) {
@@ -62,52 +59,32 @@ export class WebviewApiProvider<T extends HostCalls> implements vscode.Disposabl
         continue;
       }
 
-      // eslint-disable-next-line sonarjs/no-try-promise
-      try {
-        const postPromise = connectedView.view.webview.postMessage(event);
-
-        // Handle async failures
-        postPromise.then(
-          () => {
-            // Message sent successfully
-          },
-          (error: unknown) => {
-            this.logger.error(
-              `Failed to send event ${String(key)} to view ${connectedView.context.viewType}:${viewId}: ${getErrorMessage(error)}`
-            );
-
-            // Mark view for removal
-            failedViews.push(viewId);
-          }
-        );
-      } catch (error) {
-        // Handle synchronous exceptions from postMessage
-        this.logger.error(
-          `Exception while sending event ${String(key)} to view ${connectedView.context.viewType}:${viewId}: ${String(error)}`
-        );
-
-        // Mark view for removal
-        failedViews.push(viewId);
-      }
-    }
-
-    // Prune failed views after iteration to avoid modifying collection during iteration
-    if (failedViews.length > 0) {
-      for (const viewId of failedViews) {
-        const connectedView = this.connectedViews.get(viewId as WebviewKey);
-        if (connectedView) {
-          this.logger.warn(
-            `Removing failed webview ${connectedView.context.viewType}:${viewId} from connectedViews`
+      this.postEventToView(
+        connectedView,
+        event,
+        viewId,
+        (error) => {
+          this.pruneConnectedView(
+            viewId,
+            connectedView,
+            `Failed to send event ${String(key)} to view ${connectedView.context.viewType}:${viewId}: ${getErrorMessage(error)}`
           );
+        },
+        () => {
+          if (!this.queueHiddenEvents) {
+            this.logger.warn(
+              `Event ${String(key)} was not delivered to view ${connectedView.context.viewType}:${viewId}`
+            );
+            return;
+          }
 
-          // Only remove from connected views - let webviews handle their own disposal lifecycle
-          this.connectedViews.delete(viewId as WebviewKey);
+          this.logger.warn(
+            `Event ${String(key)} was not delivered to view ${connectedView.context.viewType}:${viewId}; re-queueing`
+          );
+          if (this.connectedViews.get(viewId) === connectedView) {
+            this.enqueueEvent(connectedView, event, viewId);
+          }
         }
-      }
-
-      this.logger.info(
-        // eslint-disable-next-line @typescript-eslint/restrict-template-expressions
-        `Removed ${failedViews.length} failed webview(s) from connectedViews. Remaining: ${this.connectedViews.size}`
       );
     }
   }
@@ -136,13 +113,17 @@ export class WebviewApiProvider<T extends HostCalls> implements vscode.Disposabl
         this.flushPendingEvents(id);
       }
     });
+    this.disposables.push(visibilityListener);
 
     // Clean up on dispose
-    view.onDidDispose(() => {
+    const disposeListener = view.onDidDispose(() => {
       visibilityListener.dispose();
-      this.connectedViews.delete(id);
-      this.logger.info(`Unregistered webview: ${view.viewType}:${id}`);
+      if (this.connectedViews.get(id)?.view === view) {
+        this.connectedViews.delete(id);
+        this.logger.info(`Unregistered webview: ${view.viewType}:${id}`);
+      }
     });
+    this.disposables.push(disposeListener);
   }
 
   /**
@@ -164,6 +145,13 @@ export class WebviewApiProvider<T extends HostCalls> implements vscode.Disposabl
   }
 
   private enqueueEvent(connectedView: ConnectedView<T>, event: ViewApiEvent<T>, viewId: string) {
+    if (this.maxQueuedEvents <= 0) {
+      this.logger.warn(
+        `Dropping event '${String(event.key)}' for hidden view ${connectedView.context.viewType}:${viewId}: maxQueuedEvents is ${String(this.maxQueuedEvents)}`
+      );
+      return;
+    }
+
     if (connectedView.pendingEvents.length >= this.maxQueuedEvents) {
       const dropped = connectedView.pendingEvents.shift();
       this.logger.warn(
@@ -190,24 +178,79 @@ export class WebviewApiProvider<T extends HostCalls> implements vscode.Disposabl
     this.logger.debug(
       `Flushing ${String(queued.length)} queued event(s) to view ${connectedView.context.viewType}:${id}`
     );
+
     for (const event of queued) {
-      // eslint-disable-next-line sonarjs/no-try-promise
-      try {
-        connectedView.view.webview.postMessage(event).then(
-          () => {
-            // Message sent successfully
-          },
-          (error: unknown) => {
-            this.logger.error(
-              `Failed to flush event ${String(event.key)} to view ${connectedView.context.viewType}:${id}: ${getErrorMessage(error)}`
-            );
+      if (this.connectedViews.get(id) !== connectedView) {
+        break;
+      }
+
+      this.postEventToView(
+        connectedView,
+        event,
+        id,
+        (error) => {
+          this.pruneConnectedView(
+            id,
+            connectedView,
+            `Failed to flush event ${String(event.key)} to view ${connectedView.context.viewType}:${id}: ${getErrorMessage(error)}`
+          );
+        },
+        () => {
+          this.logger.warn(
+            `Event ${String(event.key)} was not delivered while flushing ${connectedView.context.viewType}:${id}; re-queueing`
+          );
+          if (this.connectedViews.get(id) === connectedView) {
+            this.enqueueEvent(connectedView, event, id);
           }
-        );
-      } catch (error) {
-        this.logger.error(
-          `Exception while flushing event ${String(event.key)} to view ${connectedView.context.viewType}:${id}: ${String(error)}`
-        );
+        }
+      );
+    }
+  }
+
+  private postEventToView(
+    connectedView: ConnectedView<T>,
+    event: ViewApiEvent<T>,
+    viewId: WebviewKey,
+    onFailure: (error: unknown) => void,
+    onNotDelivered: () => void
+  ): void {
+    // eslint-disable-next-line sonarjs/no-try-promise
+    try {
+      void connectedView.view.webview.postMessage(event).then(
+        (delivered) => {
+          if (!delivered && this.connectedViews.get(viewId) === connectedView) {
+            onNotDelivered();
+          }
+        },
+        (error: unknown) => {
+          if (this.connectedViews.get(viewId) === connectedView) {
+            onFailure(error);
+          }
+        }
+      );
+    } catch (error) {
+      if (this.connectedViews.get(viewId) === connectedView) {
+        onFailure(error);
       }
     }
+  }
+
+  private pruneConnectedView(
+    viewId: WebviewKey,
+    connectedView: ConnectedView<T>,
+    reason: string
+  ): void {
+    if (this.connectedViews.get(viewId) !== connectedView) {
+      this.logger.debug(
+        `Ignoring stale failure for webview ${connectedView.context.viewType}:${viewId}`
+      );
+      return;
+    }
+
+    this.logger.error(reason);
+    this.logger.warn(
+      `Removing failed webview ${connectedView.context.viewType}:${viewId} from connectedViews`
+    );
+    this.connectedViews.delete(viewId);
   }
 }

--- a/tests/lib/host/BaseWebviewViewProvider.test.ts
+++ b/tests/lib/host/BaseWebviewViewProvider.test.ts
@@ -271,6 +271,32 @@ describe('BaseWebviewViewProvider', () => {
       expect(hookSpy).toHaveBeenCalledWith('fetchData', failure);
     });
 
+    it('should still post an actError message when onActionError throws', async () => {
+      const failure = new Error('delegate failed');
+      (provider['webviewActionDelegate'].fetchData as any).mockRejectedValueOnce(failure);
+      vi.spyOn(provider as any, 'onActionError').mockImplementationOnce(() => {
+        throw new Error('hook failed');
+      });
+      const loggerSpy = vi.spyOn(provider['logger'], 'error');
+
+      await messageCallback({
+        type: 'act',
+        providerId: 'test.provider',
+        key: 'fetchData',
+        params: ['123'],
+      });
+
+      expect(loggerSpy).toHaveBeenCalledWith(
+        expect.stringContaining("onActionError hook failed for action 'fetchData'")
+      );
+      expect(mockWebview.postMessage).toHaveBeenCalledWith({
+        type: ACT_ERROR,
+        providerId: 'test.provider',
+        key: 'fetchData',
+        error: 'delegate failed',
+      });
+    });
+
     it('should not propagate rejections from handleMessage', async () => {
       provider.handleMessage.mockRejectedValueOnce(new Error('consumer handler failed'));
       const loggerSpy = vi.spyOn(provider['logger'], 'error');
@@ -383,6 +409,24 @@ describe('BaseWebviewViewProvider', () => {
       expect(patches).toEqual([{ data: 'two' }, { data: 'three' }]);
     });
 
+    it('should drop hidden messages when maxQueuedMessages is zero', () => {
+      const zeroQueueProvider = new TestWebviewProvider(
+        'test.provider' as WebviewKey,
+        mockExtensionUri,
+        mockApiProvider,
+        { maxQueuedMessages: 0 }
+      );
+      zeroQueueProvider.resolveWebviewView(mockWebviewView, {} as any, {} as any);
+
+      mockWebviewView.visible = false;
+      zeroQueueProvider.postPatch('fetchData', { data: 'dropped' });
+
+      mockWebviewView.visible = true;
+      visibilityCallback();
+
+      expect(mockWebview.postMessage).not.toHaveBeenCalled();
+    });
+
     it('should drop messages while hidden when queueing is disabled', () => {
       const nonQueueingProvider = new TestWebviewProvider(
         'test.provider' as WebviewKey,
@@ -401,7 +445,7 @@ describe('BaseWebviewViewProvider', () => {
       expect(mockWebview.postMessage).not.toHaveBeenCalled();
     });
 
-    it('should stop posting to a disposed view and queue instead', () => {
+    it('should stop posting to a disposed view', () => {
       provider.resolveWebviewView(mockWebviewView, {} as any, {} as any);
       disposeCallback();
 
@@ -409,6 +453,32 @@ describe('BaseWebviewViewProvider', () => {
         provider.postPatch('fetchData', { data: 'after dispose' });
       }).not.toThrow();
       expect(mockWebview.postMessage).not.toHaveBeenCalled();
+    });
+
+    it('should not flush stale messages from a disposed session into a new view', () => {
+      provider.resolveWebviewView(mockWebviewView, {} as any, {} as any);
+
+      mockWebviewView.visible = false;
+      provider.postPatch('fetchData', { data: 'before dispose' });
+      disposeCallback();
+      provider.postPatch('fetchData', { data: 'after dispose' });
+
+      const nextWebview = {
+        ...mockWebview,
+        postMessage: vi.fn(),
+        onDidReceiveMessage: vi.fn(() => ({ dispose: vi.fn() })),
+      };
+      const nextWebviewView = {
+        ...mockWebviewView,
+        webview: nextWebview,
+        visible: true,
+        onDidChangeVisibility: vi.fn(() => ({ dispose: vi.fn() })),
+        onDidDispose: vi.fn(() => ({ dispose: vi.fn() })),
+      };
+
+      provider.resolveWebviewView(nextWebviewView, {} as any, {} as any);
+
+      expect(nextWebview.postMessage).not.toHaveBeenCalled();
     });
   });
 

--- a/tests/lib/host/WebviewApiProvider.test.ts
+++ b/tests/lib/host/WebviewApiProvider.test.ts
@@ -80,6 +80,59 @@ describe('WebviewApiProvider', () => {
       // View should be automatically unregistered
       expect(provider.getConnectedViewCount()).toBe(0);
     });
+
+    it('should not let an old dispose callback unregister a replacement view', () => {
+      const viewId = createWebviewKey('test-view-1');
+      let disposeOldView: (() => void) | undefined;
+      const oldView = {
+        ...mockWebviewView,
+        viewType: 'oldView',
+        webview: {
+          ...mockWebviewView.webview,
+          postMessage: vi.fn().mockResolvedValue(true),
+        },
+        onDidDispose: vi.fn((callback: () => void) => {
+          disposeOldView = callback;
+          return { dispose: vi.fn() };
+        }),
+      };
+      const newView = {
+        ...mockWebviewView,
+        viewType: 'newView',
+        webview: {
+          ...mockWebviewView.webview,
+          postMessage: vi.fn().mockResolvedValue(true),
+        },
+      };
+
+      provider.registerView(viewId, oldView);
+      provider.registerView(viewId, newView);
+      disposeOldView?.();
+
+      expect(provider.getConnectedViewCount()).toBe(1);
+
+      provider.triggerEvent('onDataUpdate', { data: 'test' });
+
+      expect(newView.webview.postMessage).toHaveBeenCalledWith({
+        type: 'event',
+        key: 'onDataUpdate',
+        value: [{ data: 'test' }],
+      });
+    });
+
+    it('should dispose visibility listeners when the provider is disposed', () => {
+      const visibilityDisposable = { dispose: vi.fn() };
+      const disposableView = {
+        ...mockWebviewView,
+        onDidChangeVisibility: vi.fn(() => visibilityDisposable),
+        onDidDispose: vi.fn(() => ({ dispose: vi.fn() })),
+      };
+
+      provider.registerView(createWebviewKey('test-view-1'), disposableView);
+      provider.dispose();
+
+      expect(visibilityDisposable.dispose).toHaveBeenCalled();
+    });
   });
 
   describe('triggerEvent', () => {
@@ -153,6 +206,7 @@ describe('WebviewApiProvider', () => {
       expect(provider.getConnectedViewCount()).toBe(2); // Both views registered
 
       provider.triggerEvent('onDataUpdate', { data: 'test' });
+      await Promise.resolve();
 
       // Verify that postMessage was called on the failing view
       expect(failingView.webview.postMessage).toHaveBeenCalledWith({
@@ -161,9 +215,7 @@ describe('WebviewApiProvider', () => {
         value: [{ data: 'test' }],
       });
 
-      // The rejection is handled asynchronously but doesn't immediately remove the view
-      // This is expected behavior - removal happens in the next event loop
-      expect(provider.getConnectedViewCount()).toBe(2);
+      expect(provider.getConnectedViewCount()).toBe(1);
     });
 
     it('should handle synchronous postMessage exceptions', () => {
@@ -279,6 +331,65 @@ describe('WebviewApiProvider', () => {
       const values = view.webview.postMessage.mock.calls.map((call: any[]) => call[0].value);
       expect(values).toEqual([[{ data: 'two' }], [{ data: 'three' }]]);
       boundedProvider.dispose();
+    });
+
+    it('should drop hidden events when maxQueuedEvents is zero', () => {
+      const zeroQueueProvider = new WebviewApiProvider<TestHostCalls>({ maxQueuedEvents: 0 });
+      const { view, show } = createHiddenView();
+      zeroQueueProvider.registerView(createWebviewKey('hidden-view'), view);
+
+      zeroQueueProvider.triggerEvent('onDataUpdate', { data: 'dropped' });
+      show();
+
+      expect(view.webview.postMessage).not.toHaveBeenCalled();
+      zeroQueueProvider.dispose();
+    });
+
+    it('should requeue queued events when flush resolves false', async () => {
+      const { view, show } = createHiddenView();
+      view.webview.postMessage = vi.fn().mockResolvedValueOnce(false).mockResolvedValueOnce(true);
+      provider.registerView(createWebviewKey('hidden-view'), view);
+
+      provider.triggerEvent('onDataUpdate', { data: 'retry' });
+      show();
+      await Promise.resolve();
+
+      expect(view.webview.postMessage).toHaveBeenCalledTimes(1);
+
+      show();
+      await Promise.resolve();
+
+      expect(view.webview.postMessage).toHaveBeenCalledTimes(2);
+      expect(view.webview.postMessage).toHaveBeenLastCalledWith({
+        type: 'event',
+        key: 'onDataUpdate',
+        value: [{ data: 'retry' }],
+      });
+    });
+
+    it('should prune a hidden view when queued event flush rejects', async () => {
+      const { view, show } = createHiddenView();
+      view.webview.postMessage = vi.fn().mockRejectedValue(new Error('flush failed'));
+      provider.registerView(createWebviewKey('hidden-view'), view);
+
+      provider.triggerEvent('onDataUpdate', { data: 'test' });
+      show();
+      await Promise.resolve();
+
+      expect(provider.getConnectedViewCount()).toBe(0);
+    });
+
+    it('should prune a hidden view when queued event flush throws', () => {
+      const { view, show } = createHiddenView();
+      view.webview.postMessage = vi.fn(() => {
+        throw new Error('flush threw');
+      });
+      provider.registerView(createWebviewKey('hidden-view'), view);
+
+      provider.triggerEvent('onDataUpdate', { data: 'test' });
+      show();
+
+      expect(provider.getConnectedViewCount()).toBe(0);
     });
 
     it('should post directly to hidden views when queueing is disabled', () => {


### PR DESCRIPTION
## Summary

- Guard webview registration cleanup so stale dispose callbacks cannot unregister replacement views.
- Harden queued message/event delivery by handling zero-sized queues, failed flushes, `postMessage(false)`, and `onActionError` hook failures.
- Update robustness docs and add regression coverage for the PR review findings.

## Root Cause

The host-side webview lifecycle code assumed dispose callbacks and `postMessage` outcomes represented the currently registered view. During reloads, hidden flushes, or action error hooks, that allowed stale registrations, lost queued events, or swallowed `ACT_ERROR` notifications.

## Validation

- `npm run typecheck`
- `npm test` (337 tests passing)
- `npm run lint`
- `npx prettier --check README.md src/lib/host/BaseWebviewViewProvider.ts src/lib/host/WebviewApiProvider.ts tests/lib/host/BaseWebviewViewProvider.test.ts tests/lib/host/WebviewApiProvider.test.ts`

Note: repo-wide `npm run format:check` still reports unrelated/generated formatting issues in `.claude/settings.local.json`, `CODE_OF_CONDUCT.md`, and `reviews_triage/pr-9-feedback-20260703-064449.json`.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/hbmartin/react-vscode-webview-ipc/pull/10?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

